### PR TITLE
chore: update jsdom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gifencoder": "^2.0.1",
     "is-url": "^1.2.4",
     "jimp": "^0.16.1",
-    "jsdom": "^15.1.1",
+    "jsdom": "^16.5.3",
     "png-file-stream": "^1.2.1"
   },
   "scripts": {


### PR DESCRIPTION
Updating to latest version, as I was having some issues with `jsdom` like:

```
 > ../node_modules/node-p5/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:30:57: warning: "./xhr-sync-worker.js" should be marked as external for use with "require.resolve"
    30 │ const syncWorkerFile = require.resolve ? require.resolve("./xhr-sync-worker.js") : null;
```

Hoping this should fix it!

Signed-off-by: campionfellin <campionfellin@gmail.com>